### PR TITLE
_checkConnectivity to return `true` as soon as it connects to one URL

### DIFF
--- a/lib/internet_connection.dart
+++ b/lib/internet_connection.dart
@@ -158,12 +158,12 @@ class InternetConnectionChecker {
     if (!requireAllAddressesToRespond) {
       try {
         // Ensure at least one successful result, even if others fail
-        final List<bool> results = await Future.wait(
+        final stream = Stream.fromFutures(
           futures.map((future) => future.then((result) => result.isSuccess)),
         );
 
-        // Return true if any result is successful
-        return results.contains(true);
+        // Return true as soon as any result is successful
+        return await stream.any((result) => result == true);
       } catch (e) {
         return false; // If all futures fail, return false
       }

--- a/lib/internet_connection.dart
+++ b/lib/internet_connection.dart
@@ -158,7 +158,7 @@ class InternetConnectionChecker {
     if (!requireAllAddressesToRespond) {
       try {
         // Ensure at least one successful result, even if others fail
-        final stream = Stream.fromFutures(
+        final Stream<bool> stream = Stream.fromFutures(
           futures.map((future) => future.then((result) => result.isSuccess)),
         );
 


### PR DESCRIPTION
## Status

**READY**

## Description

Fixing the issue https://github.com/Nightfury-5/internet_connection_checker/issues/49.

When one of the URLs `_checkConnectivity` is trying to ping is slow, it delays the function altogether as it waits for all of the URLs to respond. This means, even if all URLs respond within 100ms but one of them does not respond, we end up waiting 5 seconds. It seems like that in the current version (`3.0.1`) there is always a URL that does not respond, and it also seems it is not always the same URL. 

Therefore instead of just changing the default URLs, and risking that a URL stop responding again, I suggest a fix that will wait for the very first URL which responds with positive connectivity. I implemented Stream, so as soon as one of the URL responds with a positive connection, `_checkConnectivity` returns `true`.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
